### PR TITLE
Extend install task for multiple OS families

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,25 @@
 # tasks file for netzwirt.git-server
 
 
-- name: install git
+- name: install git on debian-like system
   apt:
     name: git
     state: present
+  when: ansible_os_family == "Debian"
+
+
+- name: install git on RH-like system
+  yum:
+    name: git
+    state: present
+  when: ansible_os_family == "RedHat"
+
+
+- name: install git on Gentoo-like system
+  portage:
+    name: dev-vcs/git
+    state: present
+  when: ansible_os_family == "Gentoo"
 
 
 - name: add git-shell to /etc/shells


### PR DESCRIPTION
Using old method of separate tasks per OS family for backwards
compatibility, because the cleaner method of using 'package' module
is only available starting with Ansible 2.0

http://serverfault.com/questions/587727/how-to-unify-package-installation-tasks-in-ansible
