### PR TITLE
Fix perms for no-interactive-login

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
   template:
     dest: /home/git/git-shell-commands/no-interactive-login
     src: no-interactive-login.j2
-    mode: 755 
+    mode: 0755
     owner: git
     group: git
 


### PR DESCRIPTION
Per the official docs for template mode parameter,
"Leaving off the leading zero will likely have unexpected results" [1]

In this case, leaving off the leading zero was the difference between
weird perms with read-by-owner missing

--wxrw--wt 1 git git 290 May  3 09:22 no-interactive-login

and the intended perms

-rwxr-xr-x 1 git git 290 May  3 09:22 no-interactive-login

[1] http://docs.ansible.com/ansible/template_module.html
